### PR TITLE
change link to Shared Nullifier Key README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository contains a collection of useful development patterns for Aztec developers to reference. All patterns are thoroughly documented and are accompanied with code examples showcasing their structure and implementation along with tests to ensure its correct functionality.
 ## Recommended Read Order
 1. [Private-Public Mirroring](https://github.com/defi-wonderland/aztec-patterns/blob/dev/patterns/private-public-mirroring/README.md)
-1. [Shared Nullifier Key](https://github.com/defi-wonderland/aztec-patterns/blob/dev/patterns/note-sharing/README.md)
+1. [Shared Nullifier Key](https://github.com/defi-wonderland/aztec-patterns/blob/dev/patterns/shared-nullifier-key/README.md)
 1. [Note Sharing](https://github.com/defi-wonderland/aztec-patterns/blob/dev/patterns/note-sharing/README.md)
 1. [Contracts as Note Owners](https://github.com/defi-wonderland/aztec-patterns/blob/dev/patterns/contracts-as-note-owners/README.md)
 1. [Immediate Note Nullification](https://github.com/defi-wonderland/aztec-patterns/blob/dev/patterns/immediate-nullification/README.md)


### PR DESCRIPTION
guys, when i was working on [this pr](https://github.com/AztecProtocol/awesome-aztec/pull/35) i have found that u have wrong link in your README.md to Shared Nullifier Key README.md